### PR TITLE
Change the versioning convention to use master as development branch …

### DIFF
--- a/ci/bump.rb
+++ b/ci/bump.rb
@@ -199,9 +199,7 @@ bump &&= ENV["TRAVIS_TAG"].to_s.empty?
 bump &&= !tagged_commits_mapping.key?(ENV["TRAVIS_COMMIT"])
 
 if bump
-  if ENV["TRAVIS_BRANCH"] == "master"
-    bump_from_master_branch
-  else
+  if ENV["TRAVIS_BRANCH"] != "master"
     bump_from_version_specific_branch(ENV["TRAVIS_BRANCH"])
   end
 end


### PR DESCRIPTION
Use master as development branch and maintain stable versions in branches
